### PR TITLE
SIMPLY-3490: Update request properties when a download token is received.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ ext.versions = [
   logback_android  : "1.1.1-6",
   logback_classic  : "1.2.3",
   mockito_android  : "2.22.0",
+  mockito_kotlin   : "2.2.0",
   mockwebserver    : "4.9.0",
   okhttp           : "4.9.0",
   slf4j_api        : "1.7.25",
@@ -124,6 +125,7 @@ ext.libraries = [
   logback_classic            : "ch.qos.logback:logback-classic:${versions.logback_classic}",
   mockwebserver              : "com.squareup.okhttp3:mockwebserver:${versions.mockwebserver}",
   mockito_android            : "org.mockito:mockito-android:${versions.mockito_android}",
+  mockito_kotlin             : "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}",
   okhttp                     : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
   slf4j                      : "org.slf4j:slf4j-api:${versions.slf4j_api}",
 ]

--- a/org.librarysimplified.http.tests/build.gradle
+++ b/org.librarysimplified.http.tests/build.gradle
@@ -15,5 +15,6 @@ dependencies {
   implementation libraries.logback_classic
   implementation libraries.mockwebserver
   implementation libraries.mockito_android
+  implementation libraries.mockito_kotlin
   implementation libraries.slf4j
 }


### PR DESCRIPTION
**What's this do?**

When a fulfill request to the CM returns a bearer token to be used to download a book, a new request is made to the download url, with the bearer token. The request properties are copied from the initial request, but the authentication property is not updated to indicate that the new request is using token auth with the returned token. This fixes that.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3490](https://jira.nypl.org/browse/SIMPLY-3490). `LSHTTPRedirectRequestInterceptor` operates on the request properties, so it needs those properties to contain accurate authentication information for the request being made.

**How should this be tested? / Do these changes have associated tests?**

In a library that uses SAML auth, download a book that is fulfilled from the distributor using a bearer token. For example, in NYU Library, "A Glass Half Full" by Sanjay Kathuria (or other books from ProQuest). The book should download successfully (not return a 401).

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this in the vanilla app.