### PR TITLE
SIMPLY-3489: Don't fail file size check when expected size is unknown.

### DIFF
--- a/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/internal/LSHTTPDownload.kt
+++ b/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/internal/LSHTTPDownload.kt
@@ -153,7 +153,7 @@ class LSHTTPDownload(
     total: Long
   ) {
     val fileLength = this.request.outputFile.length()
-    if (expectedSize != null) {
+    if (expectedSize != null && expectedSize >= 0) {
       check(fileLength == expectedSize) {
         "Output file size $fileLength must match expected size $expectedSize"
       }


### PR DESCRIPTION
**What's this do?**

Skip the downloaded file size check when the expected size is unknown. This happens when the response is chunked. In this case, [okhttp returns -1](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/content-length/) for the content length.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3489](https://jira.nypl.org/browse/SIMPLY-3489).

**How should this be tested? / Do these changes have associated tests?**

Download a book from a distributor that uses a chunked response, for example from NYU Library, "A Glass Half Full" by Sanjay Kathuria (or other books from ProQuest). The download should succeed.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.