### PR TITLE
Explicitly reject redirects with an error

### DIFF
--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
@@ -393,7 +393,7 @@ abstract class LSHTTPClientContract {
   }
 
   /**
-   * Server redirects are not followed if disabled.
+   * Server redirects are not followed if disabled, and result in an error.
    */
 
   @Test
@@ -419,7 +419,7 @@ abstract class LSHTTPClientContract {
         .build()
 
     request.execute().use { response ->
-      val status = response.status as LSHTTPResponseStatus.Responded.OK
+      val status = response.status as LSHTTPResponseStatus.Responded.Error
       Assertions.assertEquals(301, status.properties.status)
       Assertions.assertEquals(
         this.serverElsewhere.url("/abc").toString(),
@@ -796,8 +796,9 @@ abstract class LSHTTPClientContract {
         .build()
 
     request.execute().use { response ->
-      val status = response.status as LSHTTPResponseStatus.Responded.OK
+      val status = response.status as LSHTTPResponseStatus.Responded.Error
       Assertions.assertEquals(301, status.properties.status)
+      Assertions.assertEquals("Refused to follow a redirect to ${this.serverElsewhere.url("/abc")}.", status.properties.message)
       Assertions.assertEquals(
         "Redirect!",
         String(status.bodyStream?.readBytes() ?: ByteArray(0))

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
@@ -9,7 +9,7 @@ import org.librarysimplified.http.api.LSHTTPResponseType
 
 class LSHTTPRequest(
   private val client: LSHTTPClient,
-  internal val allowRedirects: AllowRedirects,
+  private val allowRedirects: AllowRedirects,
   override val properties: LSHTTPRequestProperties,
   private val modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
   private val observer: ((LSHTTPResponseType) -> Unit)?

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
@@ -9,7 +9,7 @@ import org.librarysimplified.http.api.LSHTTPResponseType
 
 class LSHTTPRequest(
   private val client: LSHTTPClient,
-  private val allowRedirects: AllowRedirects,
+  val allowRedirects: AllowRedirects,
   override val properties: LSHTTPRequestProperties,
   private val modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
   private val observer: ((LSHTTPResponseType) -> Unit)?

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
@@ -9,7 +9,7 @@ import org.librarysimplified.http.api.LSHTTPResponseType
 
 class LSHTTPRequest(
   private val client: LSHTTPClient,
-  val allowRedirects: AllowRedirects,
+  internal val allowRedirects: AllowRedirects,
   override val properties: LSHTTPRequestProperties,
   private val modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
   private val observer: ((LSHTTPResponseType) -> Unit)?

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
@@ -87,22 +87,44 @@ class LSHTTPResponse(
           cookies = cookies
         )
 
-      return if (adjustedStatus >= 400) {
-        LSHTTPResponse(
-          status = LSHTTPResponseStatus.Responded.Error(
-            properties = properties,
-            bodyStream = responseStream
-          ),
-          response = response
-        )
+      return when {
+        adjustedStatus >= 400 -> {
+          LSHTTPResponse(
+            status = LSHTTPResponseStatus.Responded.Error(
+              properties = properties,
+              bodyStream = responseStream
+            ),
+            response = response
+          )
+        }
+        adjustedStatus >= 300 -> {
+          LSHTTPResponse(
+            status = LSHTTPResponseStatus.Responded.Error(
+              properties = properties.copy(
+                message = refusedRedirectMessage(properties.header("location"))
+              ),
+              bodyStream = responseStream
+            ),
+            response = response
+          )
+        }
+        else -> {
+          LSHTTPResponse(
+            status = LSHTTPResponseStatus.Responded.OK(
+              properties = properties,
+              bodyStream = responseStream
+            ),
+            response = response
+          )
+        }
+      }
+    }
+
+    private fun refusedRedirectMessage(location: String?): String {
+      return if (location != null) {
+        "Refused to follow a redirect to ${location}."
       } else {
-        LSHTTPResponse(
-          status = LSHTTPResponseStatus.Responded.OK(
-            properties = properties,
-            bodyStream = responseStream
-          ),
-          response = response
-        )
+        "Refused to follow a redirect."
       }
     }
 


### PR DESCRIPTION
This adjusts the behaviour of the client such that, instead of
returning a 3** status code, failing to follow a redirect is treated
as an error and an appropriate error message is presented.

To clarify a little: If redirects are allowed for a response, then
redirects continue to work transparently as they always did. If
redirects are _not_ allowed for a response, or if redirects between
https and http are not allowed, then a redirect is presented as
an error to applications. Previously, a 3** status code would be
returned and applications would then tend to do the wrong things.

Fix: https://jira.nypl.org/browse/SMA-187